### PR TITLE
Turn cost-based-optimizer on

### DIFF
--- a/presto-main/etc/config.properties
+++ b/presto-main/etc/config.properties
@@ -46,3 +46,4 @@ plugin.bundles=\
 
 presto.version=testversion
 node-scheduler.include-coordinator=true
+join-distribution-type=automatic


### PR DESCRIPTION
Please let me know if creating a new version of presto with this config change is the correct way to turn on the cbo.