### PR TITLE
Generalize Okta Authentication; pass configs as param

### DIFF
--- a/presto-cli/src/main/java/io/prestosql/cli/ClientOptions.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/ClientOptions.java
@@ -47,8 +47,8 @@ public class ClientOptions
     private static final Splitter NAME_VALUE_SPLITTER = Splitter.on('=').limit(2);
     private static final CharMatcher PRINTABLE_ASCII = CharMatcher.inRange((char) 0x21, (char) 0x7E); // spaces are not allowed
 
-    @Option(name = "--server", title = "server", description = "Presto server location (default: https://prestoproxy-production.lyft.net)")
-    public String server = "https://prestoproxy-production.lyft.net";
+    @Option(name = "--server", title = "server", description = "Presto server location (default: localhost:8080)")
+    public String server = "localhost:8080";
 
     @Option(name = "--krb5-service-principal-pattern", title = "krb5 remote service principal pattern", description = "Remote kerberos service principal pattern (default: ${SERVICE}@${HOST})")
     public String krb5ServicePrincipalPattern = "${SERVICE}@${HOST}";
@@ -93,7 +93,13 @@ public class ClientOptions
     public boolean password;
 
     @Option(name = "--use-okta", title = "Okta login", description = "OpenID login with Okta")
-    public boolean useOkta = true;
+    public boolean useOkta;
+
+    @Option(name = "--okta-base-url", title = "Okta base URL", description = "Okta base URL for the organization")
+    public String oktaBaseUrl;
+
+    @Option(name = "--okta-client-id", title = "Okta PKCE Client ID", description = "Okta PKCE client ID")
+    public String oktaClientId;
 
     @Option(name = "--source", title = "source", description = "Name of source making query")
     public String source = "presto-cli";

--- a/presto-cli/src/main/java/io/prestosql/cli/Console.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/Console.java
@@ -141,6 +141,8 @@ public class Console
                 Optional.ofNullable(clientOptions.krb5ConfigPath),
                 Optional.ofNullable(clientOptions.krb5KeytabPath),
                 Optional.ofNullable(clientOptions.krb5CredentialCachePath),
+                Optional.ofNullable(clientOptions.oktaBaseUrl),
+                Optional.ofNullable(clientOptions.oktaClientId),
                 !clientOptions.krb5DisableRemoteServiceHostnameCanonicalization,
                 clientOptions.useOkta)) {
             if (hasQuery) {

--- a/presto-cli/src/main/java/io/prestosql/cli/QueryRunner.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/QueryRunner.java
@@ -186,8 +186,8 @@ public class QueryRunner
         if (useOkta) {
             log.info("Asking for okta authentication");
 
-            checkArgument(!oktaBaseUrl.isPresent() || !oktaClientId.isPresent(),
-                    "Okta Base URL and Okta app ID are required to use Okta authentication");
+            checkArgument(oktaBaseUrl.isPresent() && oktaClientId.isPresent(),
+                    "Okta Base URL and Okta client ID are required to use Okta authentication");
             User user = new User();
             Server server = new Server(5000);
             server.setHandler(new OktaAuthenticationHandler(oktaBaseUrl.get(), oktaClientId.get(), server, user));

--- a/presto-cli/src/main/java/io/prestosql/cli/QueryRunner.java
+++ b/presto-cli/src/main/java/io/prestosql/cli/QueryRunner.java
@@ -71,6 +71,8 @@ public class QueryRunner
             Optional<String> kerberosConfigPath,
             Optional<String> kerberosKeytabPath,
             Optional<String> kerberosCredentialCachePath,
+            Optional<String> oktaBaseUrl,
+            Optional<String> oktaClientId,
             boolean kerberosUseCanonicalHostname,
             boolean useOkta)
     {
@@ -89,7 +91,7 @@ public class QueryRunner
         setupHttpProxy(builder, httpProxy);
         setupBasicAuth(builder, session, user, password);
         setupTokenAuth(builder, session, accessToken);
-        setupOktaAuth(builder, session, useOkta);
+        setupOktaAuth(builder, session, useOkta, oktaBaseUrl, oktaClientId);
 
         if (kerberosRemoteServiceName.isPresent()) {
             checkArgument(session.getServer().getScheme().equalsIgnoreCase("https"),
@@ -177,13 +179,18 @@ public class QueryRunner
     private static void setupOktaAuth(
             OkHttpClient.Builder clientBuilder,
             ClientSession session,
-            boolean useOkta)
+            boolean useOkta,
+            Optional<String> oktaBaseUrl,
+            Optional<String> oktaClientId)
     {
         if (useOkta) {
             log.info("Asking for okta authentication");
+
+            checkArgument(!oktaBaseUrl.isPresent() || !oktaClientId.isPresent(),
+                    "Okta Base URL and Okta app ID are required to use Okta authentication");
             User user = new User();
             Server server = new Server(5000);
-            server.setHandler(new LyftOktaAuthenticationHandler(server, user));
+            server.setHandler(new OktaAuthenticationHandler(oktaBaseUrl.get(), oktaClientId.get(), server, user));
 
             try {
                 server.start();

--- a/presto-cli/src/test/java/io/prestosql/cli/TestClientOptions.java
+++ b/presto-cli/src/test/java/io/prestosql/cli/TestClientOptions.java
@@ -30,7 +30,7 @@ public class TestClientOptions
     public void testDefault()
     {
         ClientSession session = new ClientOptions().toClientSession();
-        assertEquals(session.getServer().toString(), "https://prestoproxy-production.lyft.net");
+        assertEquals(session.getServer().toString(), "http://localhost:8080");
         assertEquals(session.getSource(), "presto-cli");
     }
 

--- a/presto-cli/src/test/java/io/prestosql/cli/TestQueryRunner.java
+++ b/presto-cli/src/test/java/io/prestosql/cli/TestQueryRunner.java
@@ -156,6 +156,8 @@ public class TestQueryRunner
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
                 false,
                 false);
     }


### PR DESCRIPTION
**Changes**
- Default server is back to localhost
- Remove `Lyft` from Authenticator class name
- Remove Lyft specific configs. Made those as params
- Check if other required params are passed if sets `useOkta`

Now to to use Okta for authentication, user has to run
`./target/presto-cli-318-executable.jar --server https://prestoproxy-staging-internal.lyft.net --use-okta --okta-base-url <okta-url-for-organization> --okta-client-id <okta-pkce-app-client-id>`