### PR TITLE
Added config to build docker image for lyft presto fork

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM lyft/java11:7ea764c41b31e36628bcfeb52d6edaada30b26f4
+ARG IAM_ROLE
+
+COPY . /code/prestobase
+WORKDIR /code/prestobase
+
+RUN \
+     /code/prestobase/mvnw clean install -DskipTests

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,0 +1,23 @@
+name: prestobase
+description: docker images for Open Source Presto release
+repository: git@github.com:lyft/presto.git
+slack: "#presto-dev-bot"
+team_email: presto-dev@lyft.com
+credentials: false
+image_type: library
+containers:
+  - name: spin
+    command: sleep infinity
+deploy:
+  - name: staging
+    legacy: false
+    orca:
+      - orca_location: ops
+        region: iad
+    automatic: false
+  - name: production
+    legacy: false
+    orca:
+      - orca_location: ops
+        region: iad
+languages: []


### PR DESCRIPTION
Test on devbox with
`control build prestobase`

...
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 13:59 min
[INFO] Finished at: 2020-02-26T06:02:10Z
[INFO] Final Memory: 316M/1074M
[INFO] ------------------------------------------------------------------------
Removing intermediate container 70b13e88dc20
 ---> 073ebc4fc9c0
Successfully built 073ebc4fc9c0
Successfully tagged lyft/prestobase:c136fbbe473d016887b39603c9a4aa889fc1738f
2020-02-26 06:04:01,957 control.versions: INFO overriding prestobase with ref: c136fbbe473d016887b39603c9a4aa889fc1738f sha: c136fbbe473d016887b39603c9a4aa889fc1738f
{
    "built": true,
    "name": "prestobase",
    "version": "c136fbbe473d016887b39603c9a4aa889fc1738f"
}
```