### PR TITLE
Provide configurable max for columns output

### DIFF
--- a/presto-main/src/main/java/io/prestosql/SystemSessionProperties.java
+++ b/presto-main/src/main/java/io/prestosql/SystemSessionProperties.java
@@ -68,6 +68,7 @@ public final class SystemSessionProperties
     public static final String RESOURCE_OVERCOMMIT = "resource_overcommit";
     public static final String QUERY_MAX_CPU_TIME = "query_max_cpu_time";
     public static final String QUERY_MAX_STAGE_COUNT = "query_max_stage_count";
+    public static final String QUERY_MAX_COLUMNS_OUTPUT = "query_max_columns_output";
     public static final String REDISTRIBUTE_WRITES = "redistribute_writes";
     public static final String USE_PREFERRED_WRITE_PARTITIONING = "use_preferred_write_partitioning";
     public static final String SCALE_WRITERS = "scale_writers";
@@ -275,6 +276,11 @@ public final class SystemSessionProperties
                         "Temporary: Maximum number of stages a query can have",
                         queryManagerConfig.getMaxStageCount(),
                         true),
+                integerProperty(
+                        QUERY_MAX_COLUMNS_OUTPUT,
+                        "Maximum number of columns (including nesting) that are allowed to be output",
+                        queryManagerConfig.getMaxColumnsOutput(),
+                        false),
                 booleanProperty(
                         DICTIONARY_AGGREGATION,
                         "Enable optimization for aggregations on dictionaries",
@@ -695,6 +701,11 @@ public final class SystemSessionProperties
     public static int getQueryMaxStageCount(Session session)
     {
         return session.getSystemProperty(QUERY_MAX_STAGE_COUNT, Integer.class);
+    }
+
+    public static int getQueryMaxColumnsOutput(Session session)
+    {
+        return session.getSystemProperty(QUERY_MAX_COLUMNS_OUTPUT, Integer.class);
     }
 
     public static boolean planWithTableNodePartitioning(Session session)

--- a/presto-main/src/main/java/io/prestosql/execution/QueryManagerConfig.java
+++ b/presto-main/src/main/java/io/prestosql/execution/QueryManagerConfig.java
@@ -64,6 +64,8 @@ public class QueryManagerConfig
     private int requiredWorkers = 1;
     private Duration requiredWorkersMaxWait = new Duration(5, TimeUnit.MINUTES);
 
+    private int maxColumnsOutput = 100000;
+
     @Min(1)
     public int getScheduleSplitBatchSize()
     {
@@ -346,6 +348,20 @@ public class QueryManagerConfig
     public QueryManagerConfig setRequiredWorkersMaxWait(Duration requiredWorkersMaxWait)
     {
         this.requiredWorkersMaxWait = requiredWorkersMaxWait;
+        return this;
+    }
+
+    @Min(1)
+    public int getMaxColumnsOutput()
+    {
+        return maxColumnsOutput;
+    }
+
+    @Config("query.max-columns-output")
+    @ConfigDescription("Maximum number of top level columns (including nesting) allowed to be output")
+    public QueryManagerConfig setMaxColumnsOutput(int maxColumnsOutput)
+    {
+        this.maxColumnsOutput = maxColumnsOutput;
         return this;
     }
 }

--- a/presto-main/src/test/java/io/prestosql/execution/TestQueryManagerConfig.java
+++ b/presto-main/src/test/java/io/prestosql/execution/TestQueryManagerConfig.java
@@ -50,7 +50,8 @@ public class TestQueryManagerConfig
                 .setQueryMaxExecutionTime(new Duration(100, TimeUnit.DAYS))
                 .setQueryMaxCpuTime(new Duration(1_000_000_000, TimeUnit.DAYS))
                 .setRequiredWorkers(1)
-                .setRequiredWorkersMaxWait(new Duration(5, TimeUnit.MINUTES)));
+                .setRequiredWorkersMaxWait(new Duration(5, TimeUnit.MINUTES))
+                .setMaxColumnsOutput(100000));
     }
 
     @Test
@@ -78,6 +79,7 @@ public class TestQueryManagerConfig
                 .put("query.max-cpu-time", "2d")
                 .put("query-manager.required-workers", "333")
                 .put("query-manager.required-workers-max-wait", "33m")
+                .put("query.max-columns-output", "100")
                 .build();
 
         QueryManagerConfig expected = new QueryManagerConfig()
@@ -101,7 +103,8 @@ public class TestQueryManagerConfig
                 .setQueryMaxExecutionTime(new Duration(3, TimeUnit.HOURS))
                 .setQueryMaxCpuTime(new Duration(2, TimeUnit.DAYS))
                 .setRequiredWorkers(333)
-                .setRequiredWorkersMaxWait(new Duration(33, TimeUnit.MINUTES));
+                .setRequiredWorkersMaxWait(new Duration(33, TimeUnit.MINUTES))
+                .setMaxColumnsOutput(100);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Simple sanity check for max number of columns allowed to be output. This will replace our hacky prrestoproxy regexp-based check while still catching the issue upfront prior to running the query.